### PR TITLE
fix: add missing URL config to Lighthouse CI files

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,9 +43,8 @@ jobs:
           DEPLOY_URL="${{ steps.vercel-deployment.outputs.url }}"
           echo "Testing against deployment: $DEPLOY_URL"
           
-          # Replace localhost URLs in Lighthouse configs (base configs that CI configs extend)
-          sed -i "s|http://localhost:3000|$DEPLOY_URL|g" .lighthouserc.js
-          sed -i "s|http://localhost:3000|$DEPLOY_URL|g" lighthouse.mobile.config.js
+          # Replace localhost URLs in shared Lighthouse URLs file
+          sed -i "s|http://localhost:3000|$DEPLOY_URL|g" lighthouse.urls.js
       - name: Run Lighthouse audit (Desktop)
         env:
           LIGHTHOUSE_URL: ${{ steps.vercel-deployment.outputs.url }}

--- a/.lighthouserc.ci.js
+++ b/.lighthouserc.ci.js
@@ -1,6 +1,9 @@
+const urls = require('./lighthouse.urls.js')
+
 module.exports = {
   ci: {
     collect: {
+      url: urls,
       settings: {
         configPath: './lighthouserc.js',
         // skip seo crawlable in CI as crawlability is blocked on Vercel preview deployments

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,8 +1,4 @@
-const urls = [
-  'http://localhost:3000/',
-  'http://localhost:3000/success-stories',
-  'http://localhost:3000/contact',
-]
+const urls = require('./lighthouse.urls.js')
 
 module.exports = {
   ci: {

--- a/lighthouse.mobile.config.ci.js
+++ b/lighthouse.mobile.config.ci.js
@@ -1,6 +1,9 @@
+const urls = require('./lighthouse.urls.js')
+
 module.exports = {
   ci: {
     collect: {
+      url: urls,
       settings: {
         configPath: './lighthouse.mobile.config.js',
         // skip seo crawlable in CI as crawlability is blocked on Vercel preview deployments

--- a/lighthouse.mobile.config.js
+++ b/lighthouse.mobile.config.js
@@ -1,8 +1,4 @@
-const urls = [
-  'http://localhost:3000/',
-  'http://localhost:3000/success-stories',
-  'http://localhost:3000/contact',
-]
+const urls = require('./lighthouse.urls.js')
 
 module.exports = {
   ci: {

--- a/lighthouse.urls.js
+++ b/lighthouse.urls.js
@@ -1,0 +1,7 @@
+// Shared URLs for Lighthouse audits
+// In CI: These URLs are replaced with Vercel deployment URL via sed command
+module.exports = [
+  'http://localhost:3000/',
+  'http://localhost:3000/success-stories',
+  'http://localhost:3000/contact',
+]


### PR DESCRIPTION
The Lighthouse CI configs were trying to extend base configs via configPath but didn't inherit the url property, causing 'No URLs provided to collect' errors.

Changes:
- Extract URLs to shared lighthouse.urls.js file (DRY)
- Add url property to .lighthouserc.ci.js and lighthouse.mobile.config.ci.js
- Update workflow to replace URLs in shared file instead of individual configs
- All 4 Lighthouse configs now import from single source of truth

This fixes the CI failure where Lighthouse couldn't find URLs to audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized Lighthouse audit URL management for consistent testing across local and deployment environments.
  * Enhanced performance testing configuration with increased CPU throttling during audits.
  * Added skip audit for mobile crawlability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->