### PR TITLE
ci: disable `largest-contentful-paint` on ci

### DIFF
--- a/.lighthouserc.ci.js
+++ b/.lighthouserc.ci.js
@@ -7,8 +7,9 @@ const baseConfig = require('./lighthouse.desktop.base.js')
 // Deep clone to avoid mutating the base config
 const ciConfig = JSON.parse(JSON.stringify(baseConfig))
 
-// Add CI-specific setting: skip is-crawlable audit
-// (Vercel preview deployments block crawlers)
-ciConfig.ci.collect.settings.skipAudits = ['is-crawlable']
+// Add CI-specific settings:
+// - skip is-crawlable audit (Vercel preview deployments block crawlers)
+// - skip largest-contentful-paint audit (unreliable in CI environment)
+ciConfig.ci.collect.settings.skipAudits = ['is-crawlable', 'largest-contentful-paint']
 
 module.exports = ciConfig

--- a/lighthouse.mobile.config.ci.js
+++ b/lighthouse.mobile.config.ci.js
@@ -7,8 +7,9 @@ const baseConfig = require('./lighthouse.mobile.base.js')
 // Deep clone to avoid mutating the base config
 const ciConfig = JSON.parse(JSON.stringify(baseConfig))
 
-// Add CI-specific setting: skip is-crawlable audit
-// (Vercel preview deployments block crawlers)
-ciConfig.ci.collect.settings.skipAudits = ['is-crawlable']
+// Add CI-specific settings:
+// - skip is-crawlable audit (Vercel preview deployments block crawlers)
+// - skip largest-contentful-paint audit (unreliable in CI environment)
+ciConfig.ci.collect.settings.skipAudits = ['is-crawlable', 'largest-contentful-paint']
 
 module.exports = ciConfig


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Lighthouse CI configuration to adjust the set of audits evaluated during continuous integration testing across multiple environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->